### PR TITLE
Fix architecture parameter

### DIFF
--- a/src/Scoop.psm1
+++ b/src/Scoop.psm1
@@ -194,7 +194,8 @@ function Install-ScoopApp {
                 $command = @('install', $_name)
 
                 if ($PSBoundParameters.ContainsKey('Architecture')) {
-                    $command += "--arch $Architecture"
+                    $command += "--arch"
+                    $command += $Architecture
                 }
 
                 if ($Global) { $command += "--global" }


### PR DESCRIPTION
```
PS C:\> Install-ScoopApp -Name 7zip -Architecture 32bit -Verbose
VERBOSE: Performing the operation "Install-ScoopApp" on target "7zip".
VERBOSE: scoop install 7zip --arch 32bit
VERBOSE: scoop install: Option --arch 32bit not recognized.
```